### PR TITLE
Local modules source is a simple string

### DIFF
--- a/blastradius/handlers/terraform.py
+++ b/blastradius/handlers/terraform.py
@@ -36,7 +36,7 @@ class Terraform:
             for name, mod in [(k, v) for x in self.config['module'] for (k, v) in x.items()]:
                 if 'source' not in mod:
                     continue
-                source = mod['source'][0]
+                source = mod['source']
 
                 path = os.path.join(self.directory, source)
                 if os.path.exists(path):


### PR DESCRIPTION
this was causing a recursive error where the source ended being '.'

i don't know if this applies to everyone, but in my case, it failed.
i'm starting this PR as a discussion, as i dont have the whole context of why that is there.